### PR TITLE
Submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "srfi-213"]
+	path = srfi-213
+	url = git@github.com:scheme-requests-for-implementation/srfi-213.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "srfi-213"]
-	path = srfi-213
-	url = git@github.com:scheme-requests-for-implementation/srfi-213.git

--- a/srfi-213/README.org
+++ b/srfi-213/README.org
@@ -1,2 +1,0 @@
-This otherwise-empty directory is here to facilitate including the
-SRFI 213 dependency as a Git submodule.


### PR DESCRIPTION
Restores the submodule functionality.

An extra file cannot be added to a submodule folder:

$ git add README.org 
fatal: In nicht ausgechecktem Submodul 'srfi-213'.
